### PR TITLE
Use runserver_plus as the development server

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./dev/django.Dockerfile
     command: [
       "./manage.py",
-      "runserver", "0.0.0.0:8000"
+      "runserver_plus", "0.0.0.0:8000"
     ]
     tty: true
     environment:

--- a/mixtape/settings/development.py
+++ b/mixtape/settings/development.py
@@ -10,7 +10,7 @@ INSTALLED_APPS += [
     'debug_toolbar',
     'django_browser_reload',
 ]
-# Force WhiteNoice to serve static files, even when using 'manage.py runserver'
+# Force WhiteNoice to serve static files, even when using 'manage.py runserver_plus'
 staticfiles_index = INSTALLED_APPS.index('django.contrib.staticfiles')
 INSTALLED_APPS.insert(staticfiles_index, 'whitenoise.runserver_nostatic')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
   "django-minio-storage",
   "django-s3-file-field[minio]",
   "ipython",
+  "watchdog",
   "werkzeug",
 ]
 


### PR DESCRIPTION
https://django-extensions.readthedocs.io/en/latest/runserver_plus.html