### PR TITLE
Rename the "development" extra to follow upstream practices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
+development = [
   # Runtime dependendencies, only needed with "development" settings
   "django-browser-reload",
   "django-debug-toolbar",
@@ -67,8 +67,9 @@ dev = [
 [dependency-groups]
 dev = [
   # Additional developer tools
-  # The "dev" dependency group is installed by default, so use this to install "dev" extras too
-  "mixtape[dev]",
+  # The "dev" dependency group is installed by default,
+  # so use this to install "development" extras by default too
+  "mixtape[development]",
   "tox",
   "tox-uv",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ runner = uv-venv-lock-runner
 pass_env =
     DJANGO_*
 extras =
-    dev
+    development
 
 [testenv:lint]
 package = skip


### PR DESCRIPTION
This also had a potential conflict with the "dev" dependency group.