### PR TITLE
Explicitly convert Numpy objects to native Python objects

### DIFF
--- a/mixtape/core/migrations/0002_initial.py
+++ b/mixtape/core/migrations/0002_initial.py
@@ -3,8 +3,6 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
-import mixtape.core.ray_utils.utility_functions
-
 
 class Migration(migrations.Migration):
 
@@ -143,7 +141,7 @@ class Migration(migrations.Migration):
                 ('reward', models.FloatField()),
                 (
                     'observation_space',
-                    models.JSONField(encoder=mixtape.core.ray_utils.json_encoder.CustomJSONEncoder),
+                    models.JSONField(),
                 ),
                 (
                     'step',

--- a/mixtape/core/migrations/0007_alter_actionmapping_mapping_alter_inference_config_and_more.py
+++ b/mixtape/core/migrations/0007_alter_actionmapping_mapping_alter_inference_config_and_more.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='actionmapping',
             name='mapping',
-            field=models.JSONField(encoder=mixtape.core.ray_utils.json_encoder.CustomJSONEncoder),
+            field=models.JSONField(),
         ),
         migrations.AlterField(
             model_name='inference',

--- a/mixtape/core/migrations/0008_remove_agentstep_reward_agentstep_rewards_and_more.py
+++ b/mixtape/core/migrations/0008_remove_agentstep_reward_agentstep_rewards_and_more.py
@@ -3,7 +3,6 @@
 from django.db import migrations, models
 
 import mixtape.core.models.agent_step
-import mixtape.core.ray_utils.json_encoder
 
 
 class Migration(migrations.Migration):
@@ -20,16 +19,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='agentstep',
             name='rewards',
-            field=models.JSONField(
-                default=mixtape.core.models.agent_step._rewards_default,
-                encoder=mixtape.core.ray_utils.json_encoder.CustomJSONEncoder,
-            ),
+            field=models.JSONField(default=mixtape.core.models.agent_step._rewards_default),
         ),
         migrations.AddField(
             model_name='training',
             name='reward_mapping',
-            field=models.JSONField(
-                blank=True, encoder=mixtape.core.ray_utils.json_encoder.CustomJSONEncoder, null=True
-            ),
+            field=models.JSONField(blank=True, null=True),
         ),
     ]

--- a/mixtape/core/migrations/0009_agentstep_action_distribution.py
+++ b/mixtape/core/migrations/0009_agentstep_action_distribution.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations, models
 
-import mixtape.core.ray_utils.json_encoder
-
 
 class Migration(migrations.Migration):
 
@@ -15,8 +13,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='agentstep',
             name='action_distribution',
-            field=models.JSONField(
-                blank=True, encoder=mixtape.core.ray_utils.json_encoder.CustomJSONEncoder, null=True
-            ),
+            field=models.JSONField(blank=True, null=True),
         ),
     ]

--- a/mixtape/core/models/action_mapping.py
+++ b/mixtape/core/models/action_mapping.py
@@ -1,7 +1,5 @@
 from django.db import models
 
-from mixtape.core.ray_utils.json_encoder import CustomJSONEncoder
-
 
 class ActionMapping(models.Model):
     class Meta:
@@ -10,4 +8,4 @@ class ActionMapping(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
     environment = models.CharField(max_length=200)
-    mapping = models.JSONField(encoder=CustomJSONEncoder)
+    mapping = models.JSONField()

--- a/mixtape/core/models/agent_step.py
+++ b/mixtape/core/models/agent_step.py
@@ -1,7 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from mixtape.core.ray_utils.json_encoder import CustomJSONEncoder
 from mixtape.core.ray_utils.utility_functions import get_environment_mapping
 
 from .step import Step
@@ -19,10 +18,10 @@ class AgentStep(models.Model):
     agent = models.CharField(max_length=200)
 
     action = models.FloatField()
-    rewards = models.JSONField(encoder=CustomJSONEncoder, default=_rewards_default)
-    observation_space = models.JSONField(encoder=CustomJSONEncoder)
+    rewards = models.JSONField(default=_rewards_default)
+    observation_space = models.JSONField()
 
-    action_distribution = models.JSONField(encoder=CustomJSONEncoder, null=True, blank=True)
+    action_distribution = models.JSONField(null=True, blank=True)
 
     def clean(self):
         # Validate that it matches the training's reward mapping length

--- a/mixtape/core/models/training.py
+++ b/mixtape/core/models/training.py
@@ -17,7 +17,7 @@ class Training(models.Model):
     config = models.JSONField(default=dict, blank=True, null=True, encoder=CustomJSONEncoder)
 
     # Reward mapping for environments with multiple reward components
-    reward_mapping = models.JSONField(encoder=CustomJSONEncoder, null=True, blank=True)
+    reward_mapping = models.JSONField(null=True, blank=True)
 
     is_external = models.BooleanField(default=False)
 

--- a/mixtape/core/tasks/inference_tasks.py
+++ b/mixtape/core/tasks/inference_tasks.py
@@ -65,8 +65,12 @@ def run_inference_task(inference_pk: int):
                             step=step_model,
                             action=action,
                             rewards=[reward],
-                            observation_space=observation,
-                            action_distribution=extras.get('action_dist_inputs'),
+                            observation_space=observation.tolist(),
+                            action_distribution=(
+                                extras['action_dist_inputs'].tolist()
+                                if 'action_dist_inputs' in extras
+                                else None
+                            ),
                         )
                         agent_step.full_clean()
                         agent_step.save()
@@ -104,9 +108,13 @@ def run_inference_task(inference_pk: int):
                                 agent=agent,
                                 step=step_model,
                                 action=actions[agent],
+                                observation_space=observations[agent].tolist(),
                                 rewards=[rewards[agent]],
-                                observation_space=observations[agent],
-                                action_distribution=action_distributions[agent],
+                                action_distribution=(
+                                    action_distributions[agent].tolist()
+                                    if action_distributions[agent] is not None
+                                    else None
+                                ),
                             )
                             agent_step.full_clean()
                             agent_step.save()
@@ -143,8 +151,12 @@ def run_inference_task(inference_pk: int):
                                 step=step_model,
                                 action=action,
                                 rewards=[reward],
-                                observation_space=observation,
-                                action_distribution=extras.get('action_dist_inputs'),
+                                observation_space=observation.tolist(),
+                                action_distribution=(
+                                    extras['action_dist_inputs'].tolist()
+                                    if 'action_dist_inputs' in extras
+                                    else None
+                                ),
                             )
                             agent_step.full_clean()
                             agent_step.save()


### PR DESCRIPTION
Trying to rely on the `CustomJSONEncoder` causes issues where Django is unable to validate Numpy objects.